### PR TITLE
Create SecureStorageLinkerOverride.cs

### DIFF
--- a/SecureStorageSample/Droid/SecureStorageLinkerOverride.cs
+++ b/SecureStorageSample/Droid/SecureStorageLinkerOverride.cs
@@ -1,0 +1,18 @@
+using System;
+using Plugin.SecureStorage;
+
+namespace AppConsume.Droid
+{
+    public static class LinkerPreserve
+    {
+        static LinkerPreserve()
+        {
+            throw new Exception(typeof(SecureStorageImplementation).FullName);
+        }
+    }
+
+    public class PreserveAttribute : Attribute
+    {
+    }
+
+}


### PR DESCRIPTION
This file helps to fix a problem at runtime "System.TypeLoadException: Could not resolve type with token 01000019" #6  in Debug Mode in VS 2015. 
Before adding this file I had to run the project in Release Mode, or in Debug mode but selecting Linking: "SDK Assemblies Only" in Project Properties -> Android Options -> Linker
